### PR TITLE
Add basic Reusable Go workflow

### DIFF
--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -1,0 +1,127 @@
+name: Common Go
+
+on:
+  workflow_call:
+    inputs:
+      static-analysis-excludes-regex:
+        type: string
+      # TODO(wenvous): gofmt is harder to work with since it always recursively
+      # formats files instead of restricting itself to just listed packages.
+      # See if there is a way to have the same behaviour without relying on the
+      # tool.
+      skip-gofmt:
+        type: boolean
+      skip-govet:
+        type: boolean
+      skip-staticcheck:
+        type: boolean
+      skip-race-tests:
+        type: boolean
+      race-tests-excludes-regex:
+        type: boolean
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.19', '1.20', '1.x']
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Build packages
+        run: go build -v ./...
+
+      - name: Run Tests
+        run: go test -v ./...
+
+      - name: Run race tests
+        if: ${{ !inputs.skip-race-tests }}
+        run: |
+          if [ -z "${{ inputs.race-tests-excludes-regex }}" ]; then
+            echo "Running for all packages"
+            go test -race -v ./...
+          else
+            echo "Running for non-excluded packages"
+            go test -race -v $(go list ./... | egrep -v "${{ inputs.race-tests-excludes-regex }}")
+          fi
+
+  static_analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.x'
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+
+      - name: Go Mod should be tidy
+        run: |
+          go mod tidy
+          diff -u <(echo -n) <(git diff)
+
+      - name: Go vet
+        if: ${{ !cancelled() && !inputs.skip-govet }}
+        run: |
+          if [ -z "${{ inputs.static-analysis-excludes-regex }}" ]; then
+            echo "Running for all packages"
+            go vet ./...
+          else
+            echo "Running for non-excluded packages"
+            go vet $(go list ./... | egrep -v "${{ inputs.static-analysis-excludes-regex }}")
+          fi
+
+      - name: Gofmt
+        if: ${{ !cancelled() && !inputs.skip-gofmt }}
+        run: |
+          diff -u <(echo -n) <(gofmt -d -s .)
+
+      - name: Run coverage
+        if: '!cancelled()'
+        run: |
+          go test -v -coverprofile=profile.cov ./...
+
+      - name: Submit coverage
+        if: '!cancelled()'
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: profile.cov
+
+      - name: Install staticcheck
+        if: '!cancelled()'
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Staticcheck
+        if: ${{ !cancelled() && !inputs.skip-staticcheck }}
+        run: |
+          if [ -z "${{ inputs.static-analysis-excludes-regex }}" ]; then
+            echo "Running for all packages"
+            staticcheck ./...
+          else
+            echo "Running for non-excluded packages"
+            staticcheck $(go list ./... | egrep -v ${{ inputs.static-analysis-excludes-regex }})
+          fi


### PR DESCRIPTION
I will look at adding golangci-lint next, which will be declared as a different reusable workflow.

Passes for the following repos:
* https://github.com/openconfig/goyang/pull/249
* https://github.com/openconfig/ygnmi/pull/122
* https://github.com/openconfig/gnoi/pull/129
* https://github.com/openconfig/lsdbparse/pull/13
* https://github.com/openconfig/models-ci/pull/87

For gribigo the CI is currently disabled due to a period of inactivity, it needs to be manually enabled:
* https://github.com/openconfig/gribigo/pull/185