### PR TITLE
Add a flag to exclude deprecated warnings from `basic_go`.

### DIFF
--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -190,7 +190,7 @@ jobs:
         run: |
           export STATICCHECK_CACHE="${{ runner.temp }}/staticcheck"
           if [ -z "${{ inputs.static-analysis-excludes-deprecated }}" ]; then
-            STATICHECK_ARGS=""
+            STATICCHECK_ARGS=""
           else
             STATICCHECK_ARGS="-SA1019"
           fi

--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -189,7 +189,7 @@ jobs:
         if: ${{ !cancelled() && !inputs.skip-staticcheck }}
         run: |
           export STATICCHECK_CACHE="${{ runner.temp }}/staticcheck"
-          if [ -z "${{ inputs.static-analysis-excludes-deprecated }}"]; then
+          if [ -z "${{ inputs.static-analysis-excludes-deprecated }}" ]; then
             STATICHECK_ARGS=""
           else
             STATICCHECK_ARGS="-SA1019"

--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -13,6 +13,8 @@ on:
         default: 'latest'
       static-analysis-excludes-regex:
         type: string
+      static-analysis-excludes-deprecated:
+        type: boolean
       # TODO(wenvous): gofmt is harder to work with since it always recursively
       # formats files instead of restricting itself to just listed packages.
       # See if there is a way to have the same behaviour without relying on the
@@ -187,10 +189,15 @@ jobs:
         if: ${{ !cancelled() && !inputs.skip-staticcheck }}
         run: |
           export STATICCHECK_CACHE="${{ runner.temp }}/staticcheck"
+          if [ -z "${{ inputs.static-analysis-excludes-deprecated }}"]; then
+            STATICHECK_ARGS=""
+          else
+            STATICCHECK_ARGS="-SA1019"
+          fi
           if [ -z "${{ inputs.static-analysis-excludes-regex }}" ]; then
             echo "Running for all packages"
-            GOGC=30 staticcheck ./...
+            GOGC=30 staticcheck ${STATICCHECK_ARGS} ./...
           else
             echo "Running for non-excluded packages"
-            GOGC=30 staticcheck $(go list ./... | grep -E -v ${{ inputs.static-analysis-excludes-regex }})
+            GOGC=30 staticcheck ${STATICCHECK_ARGS} $(go list ./... | grep -E -v ${{ inputs.static-analysis-excludes-regex }})
           fi


### PR DESCRIPTION
This fixes an issue seen in `openconfig/gnoi` where we have `SA1019` being triggered based on deprecated fields that are in generated protobufs.
