### PR TITLE
Add mechanism to add apt packages during basic_go.

### DIFF
--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -200,6 +200,13 @@ jobs:
           key: ${{ github.job }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ github.job }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
 
+      - name: Install additional dependencies
+        run: |
+          if [ -n "${{ inputs.install-additional-apt-packages }}" ]; then
+            echo "Installing additional packages"
+            sudo apt-get install ${{ inputs.install-additional-apt-packages }}
+          fi
+
       - name: Staticcheck
         if: ${{ !cancelled() && !inputs.skip-staticcheck }}
         run: |

--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -34,6 +34,9 @@ on:
         type: boolean
       skip-race-tests:
         type: boolean
+      install-additional-apt-packages:
+        type: string
+        description: "apt-get install additional apt packages"
 
 jobs:
   build_and_test:
@@ -57,6 +60,13 @@ jobs:
       - name: Get dependencies
         run: |
           go mod download
+
+      - name: Install additional dependencies
+        run: |
+          if [ -z "${{ inputs.install-additional-apt-packages }}" ]; then
+            echo "Installing additional packages"
+            sudo apt-get install ${{ inputs.install-additional-apt-packages }}
+          fi
 
       - name: Build packages
         run: go build -v ./...

--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install additional dependencies
         run: |
-          if [ -z "${{ inputs.install-additional-apt-packages }}" ]; then
+          if [ -n "${{ inputs.install-additional-apt-packages }}" ]; then
             echo "Installing additional packages"
             sudo apt-get install ${{ inputs.install-additional-apt-packages }}
           fi

--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -110,6 +110,13 @@ jobs:
         run: |
           go mod download
 
+      - name: Install additional dependencies
+        run: |
+          if [ -n "${{ inputs.install-additional-apt-packages }}" ]; then
+            echo "Installing additional packages"
+            sudo apt-get install ${{ inputs.install-additional-apt-packages }}
+          fi
+
       - name: Go Mod should be tidy
         run: |
           go mod tidy


### PR DESCRIPTION
```
commit ea3c87bfe5aed98923fc7fdfd7137ed79b48a6d4
Author: Rob Shakir <robjs@google.com>
Date:   Mon Jan 6 20:57:27 2025 +0000

    Add the ability to install additional package dependencies.
    
     * (M) .github/workflows/basic_go.yml
       - Allow a user to apt-get install packages whilst using the common
         workflow.
```
