### PR TITLE
Use pinned action version and allow failures.

### DIFF
--- a/.github/workflows/basic_go.yml
+++ b/.github/workflows/basic_go.yml
@@ -191,15 +191,12 @@ jobs:
             go test -v -coverprofile=profile.cov $(go list ./... | grep -E -v "${COVERAGE_EXCLUDES_REGEX}")
           fi
 
-      - name: Install goveralls
-        if: ${{ !cancelled() }}
-        run: go install github.com/mattn/goveralls@latest
-
       - name: Submit coverage
         if: ${{ !cancelled() }}
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: goveralls -coverprofile=profile.cov -service=github
+        continue-on-error: true
+        uses: shogo82148/actions-goveralls@25f5320d970fb565100cf1993ada29be1bb196a1 # v1.10.0
+        with:
+          path-to-profile: profile.cov
 
   staticcheck:
     name: staticcheck

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,15 +70,12 @@ jobs:
             go test -v -coverprofile=profile.cov $(go list ./... | grep -E -v "${COVERAGE_EXCLUDES_REGEX}")
           fi
 
-      - name: Install goveralls
-        if: ${{ matrix.go == fromJson(inputs.go-versions)[0] }}
-        run: go install github.com/mattn/goveralls@latest
-
       - name: Submit coverage
-        if: ${{ matrix.go == fromJson(inputs.go-versions)[0] }}
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: goveralls -coverprofile=profile.cov -service=github
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: shogo82148/actions-goveralls@25f5320d970fb565100cf1993ada29be1bb196a1 # v1.10.0
+        with:
+          path-to-profile: profile.cov
 
       - name: Run Tests
         env:


### PR DESCRIPTION
* Add continue-on-error when submitting coverage in case the coveralls service is down.
* Use the action shogo82148/actions-goveralls (with version pinning) instead of manually running `go install`.