### PR TITLE
Disable go module linting in super-linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,6 +29,7 @@ jobs:
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_BIOME_LINT: false
           VALIDATE_GO: false
+          VALIDATE_GO_MODULES: false
           VALIDATE_HTML: false
           VALIDATE_KUBERNETES_KUBECONFORM: false
           VALIDATE_JSCPD: false


### PR DESCRIPTION
VALIDATE_GO_MODULES will not work on repositories with no .go files alongside the go.mod in the root of the repositories, ie:

```
/
  - go.mod
  - README.md
/pkg/foo
  - foo.go
/cmd
  - main.go
```

I don't think it is reasonable to require a dummy go file in the root of each repo to make this linter pass. We have similar linting in the Go workflows (go.yml) to deal with the gap this creates.